### PR TITLE
re-register DataSetObserver whenever the PagerAdapter changes

### DIFF
--- a/pageindicatorview/src/main/java/com/rd/PageIndicatorView.java
+++ b/pageindicatorview/src/main/java/com/rd/PageIndicatorView.java
@@ -157,6 +157,13 @@ public class PageIndicatorView extends View implements ViewPager.OnPageChangeLis
 
     @Override
     public void onAdapterChanged(@NonNull ViewPager viewPager, @Nullable PagerAdapter oldAdapter, @Nullable PagerAdapter newAdapter) {
+        if (manager.indicator().isDynamicCount()) {
+            if (oldAdapter != null && setObserver != null) {
+                oldAdapter.unregisterDataSetObserver(setObserver);
+                setObserver = null;
+            }
+            registerSetObserver();
+        }
         updateState();
     }
 


### PR DESCRIPTION
## Problem
If `app:piv_dynamicCount="true"` is set, we register a `DataSetObserver` on the `PagerAdapter` of the `ViewPager` to get notified of data changes and update the page count accordingly.
If however the `PagerAdapter` changes later on, we don't re-register on the new `PagerAdapter` and thus fail to update the page count for future data set changes of the `ViewPager`.

## Solution
Re-register the `DataSetObserver` whenever the `PagerAdapter` changes.

